### PR TITLE
Change Response::Other to more closely match RFC grammar

### DIFF
--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -2,7 +2,7 @@ use nom::FindSubstring;
 use smtp_codec::{
     parse::{
         command::command,
-        response::{ehlo_ok_rsp, Greeting, Reply_line},
+        response::{ehlo_ok_rsp, Greeting, Reply_lines},
     },
     types::Command,
 };
@@ -28,7 +28,7 @@ fn parse_trace(mut trace: &[u8]) {
                 trace = rem;
             }
             Command::Data { .. } => {
-                let (rem, rsp) = Reply_line(trace).unwrap();
+                let (rem, rsp) = Reply_lines(trace).unwrap();
                 println!("S: {:?}", rsp);
                 trace = rem;
 
@@ -37,12 +37,12 @@ fn parse_trace(mut trace: &[u8]) {
                 println!("C (data): <{}>", std::str::from_utf8(data).unwrap());
                 trace = rem;
 
-                let (rem, rsp) = Reply_line(trace).unwrap();
+                let (rem, rsp) = Reply_lines(trace).unwrap();
                 println!("S: {:?}", rsp);
                 trace = rem;
             }
             _ => {
-                let (rem, rsp) = Reply_line(trace).unwrap();
+                let (rem, rsp) = Reply_lines(trace).unwrap();
                 println!("S: {:?}", rsp);
                 trace = rem;
             }


### PR DESCRIPTION
In trying to figure out how to parse client commands in our server @InstantDomain, it looks like there's currently nothing in `parser::response` that will yield a `Response::Other`. In order to more closely match the structure from the RFC (in particular the grammar from https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2), redefine `Response::Other` to expose the full response directly with more precision in the types.

Relevant grammar for reference:

```abnf
Greeting = ( "220 " (Domain / address-literal) [ SP textstring ] CRLF ) /
           (
               "220-" (Domain / address-literal) [ SP textstring ] CRLF
            *( "220-" [ textstring ] CRLF )
               "220" [ SP textstring ] CRLF
           )

textstring = 1*(%d09 / %d32-126) ; HT, SP, Printable US-ASCII

Reply-line = *( Reply-code "-" [ textstring ] CRLF )
                Reply-code [ SP textstring ] CRLF

Reply-code = %x32-35 %x30-35 %x30-39
```

Given that the new defintion of `Response::Other` can encompass the definition of the `Ehlo` variant, we could consider doing away with that variant (at the cost of clients having to do extra work extracting the greeting and domain from the first line of the response).