### PR TITLE
Typed support for SIZE parameter (RFC 1870)

### DIFF
--- a/examples/parse_command.rs
+++ b/examples/parse_command.rs
@@ -37,7 +37,7 @@ fn main() -> std::io::Result<()> {
 
             let mut line = String::new();
             std::io::stdin().read_line(&mut line)?;
-            line.replace("\n", "\r\n")
+            line.replace('\n', "\r\n")
         };
 
         if line.trim() == "exit" {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -67,7 +67,7 @@ pub fn Quoted_string(input: &[u8]) -> IResult<&[u8], Cow<'_, str>> {
             map_res(recognize(many0(QcontentSMTP)), std::str::from_utf8),
             DQUOTE,
         ),
-        |s| unescape_quoted(s),
+        unescape_quoted,
     )(input)
 }
 

--- a/src/parse/response.rs
+++ b/src/parse/response.rs
@@ -116,7 +116,7 @@ pub fn Reply_code(input: &[u8]) -> IResult<&[u8], u16> {
             take_while_m_n(3, 3, nom::character::is_digit),
             std::str::from_utf8,
         ),
-        |s| u16::from_str_radix(s, 10),
+        str::parse,
     )(input)
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -289,6 +289,7 @@ impl AtomOrQuoted {
 
 #[cfg_attr(feature = "serdex", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Response {
     Greeting {
         domain: String,
@@ -409,6 +410,7 @@ impl Response {
 
 #[cfg_attr(feature = "serdex", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Capability {
     // Send as mail [RFC821]
     // The description of SEND was updated by [RFC1123] and then its actual use was deprecated in [RFC2821]
@@ -591,6 +593,7 @@ impl Capability {
 
 #[cfg_attr(feature = "serdex", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AuthMechanism {
     Plain,
     Login,

--- a/src/types.rs
+++ b/src/types.rs
@@ -655,7 +655,7 @@ mod tests {
             ),
         ];
 
-        for (test, expected) in tests.into_iter() {
+        for (test, expected) in tests.iter() {
             let mut got = Vec::new();
             test.serialize(&mut got).unwrap();
             assert_eq!(expected, &got);
@@ -699,7 +699,7 @@ mod tests {
             ),
         ];
 
-        for (test, expected) in tests.into_iter() {
+        for (test, expected) in tests.iter() {
             let mut got = Vec::new();
             test.serialize(&mut got).unwrap();
             assert_eq!(expected, &got);
@@ -732,7 +732,7 @@ mod tests {
             ),
         ];
 
-        for (test, expected) in tests.into_iter() {
+        for (test, expected) in tests.iter() {
             let mut got = Vec::new();
             test.serialize(&mut got).unwrap();
             assert_eq!(expected, &got);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,11 +4,11 @@ pub(crate) fn escape_quoted(unescaped: &str) -> Cow<str> {
     let mut escaped = Cow::Borrowed(unescaped);
 
     if escaped.contains('\\') {
-        escaped = Cow::Owned(escaped.replace("\\", "\\\\"));
+        escaped = Cow::Owned(escaped.replace('\\', "\\\\"));
     }
 
     if escaped.contains('\"') {
-        escaped = Cow::Owned(escaped.replace("\"", "\\\""));
+        escaped = Cow::Owned(escaped.replace('\"', "\\\""));
     }
 
     escaped


### PR DESCRIPTION
This PR main adds typed support for SIZE parameter but also:

* makes `Parameter` type an enum so future type support for other parameters can be more easily added. ~~Note that such addtions would still be an API-breaks though since the enum is exhaustive (I'm happy to change that as well if desired).~~ Note that the enum is non-exhaustive so that future variant addtions would not cause API breaks.
* Fixes a bunch of clippy warnings.